### PR TITLE
fix typos

### DIFF
--- a/docs/transponder-characteristics.md
+++ b/docs/transponder-characteristics.md
@@ -8,21 +8,21 @@ Wally Ritchie
 This paper provides preliminary information regarding the expected characteristics of the P4XT Digital Muliplexed Transponder (DMT). The primary purpose is to support analysis associated with link budgets. It should also be useful as a primer to the architecture of the DMT, especially when used in conjunction with the P4XT Workshop Presentation available from the ORI site at .
 
 ### Scope
-This document provides preliminary information that should be understood as provision and subject to change as the design progresses. Nevertheless, these characteristics are expected to be close to the final design with respect to link budgeting.
+This document provides preliminary information that should be understood as provisional and subject to change as the design progresses. Nevertheless, these characteristics are expected to be close to the final design with respect to link budgeting.
 
 ## Description
 
 ### General Architecture
 
-The DMT is designed to provide a relay service in Geosynchronous Order for Amateur Radio Satellite service earth stations. The design is all digital including digital only uplinks and a single digital downlink. The onboard multiplexors provide the digital uplink data and pass it through the single downlink.
-Although designed primarily for Geo, the DMT is also useful in HEO and other scenarios where symbol rates of around 0.4Mbaud to 8Mbaud are feasible. The DVB-S2 transmitter is useful over a wider range of symbol rates where different multiplexing schemes are more appropriate including non-relay applications.
-It is important to recognize that this architecture is radically different from that of a convention bent pipe transporter, whether regenerative or not. The DMT is a receiver – multiplexor – transmitter chain with processing that determines whether data is forwarded from uplink to downlink. Except for some special modes to support transfer of digitized analog uplink waveforms, only digital transmissions are supported which may carry real-time voice/data, and IP packets.
+The DMT is designed to provide a relay service in geosynchronous orbit for Amateur Radio Satellite service earth stations. The design is all digital including digital only uplinks and a single digital downlink. The onboard multiplexors provide the digital uplink data and pass it through the single downlink.
+Although designed primarily for GEO, the DMT is also useful in HEO and other scenarios where symbol rates of around 0.4Mbaud to 8Mbaud are feasible. The DVB-S2 transmitter is useful over a wider range of symbol rates where different multiplexing schemes are more appropriate including non-relay applications.
+It is important to recognize that this architecture is radically different from that of a convention bent pipe transporter, whether regenerative or not. The DMT is a receiver – multiplexor – transmitter chain with processing that determines whether data is forwarded from uplink to downlink. Except for some special modes to support transfer of digitized analog uplink waveforms, only digital transmissions are supported which may carry real-time voice/data and IP packets.
 
 ## Uplink
 
 ### Introduction
 
-The receive subsystem has both narrowband and wideband multichannel receivers. We will focus on the narrowband receiver as this will be the one used by 99% or more ordinary amateur radio stations.
+The receive subsystem has both narrowband and wideband multichannel receivers. We will focus on the narrowband receiver as this will be the one used by 99% or more or ordinary amateur radio stations.
 
 ## Isochronous Operation
 
@@ -39,14 +39,14 @@ The baseline coding is convolutional coding supporting at least ½ and ¾ rates 
 
 ## Framing
 
-The uplink is framed at the 25 frame per second rate resulting in a frame size of 100 symbols or 100 raw bits at ½ fec. This rate provides 96 payload bits plus 4 control bits that can be passed to the multiplex and/or controller. The 96 payload bits provide 2400 bps of error corrected bandwidth. The ¾ rate fec extends this to 3600 bps and the ¼ rate fec reduces it to 1200 bps.  These are all in the range of data rates useful in amateur digital voice and data applications in HF and VHF. With current codec technologies (e.g. LPCNet + Codec2), performance that far exceeding that of the codecs deployed in amateur digital radio are viable. The symbol rate can be doubles to double the payloads to 2400, 4800, and 7200 bps which can provide high quality wideband voice. Note that these are real-time conversational modes. Arbitrarily high voice quality can be achieved using store-and-forward messaging modes. 
-160 channels are provided occupying 2 MHz of uplink bandwidth. Note that wideband channels may occupy an additional 2MHZ or more of bandwidth. (The bands are split in the front-end digital processing using fft’s). 160 channels can support 320 users in PTT mode and more than a thousand channels in NET mode. Essentially, idle stations are parked and gain the channel when the current occupant drops. This process is assisted by the protocols. Operation is also possible with 1 channel per use which supports 160 simulations users for fox like operation.
+The uplink is framed at the 25 frame per second rate resulting in a frame size of 100 symbols or 100 raw bits at ½ fec. This rate provides 96 payload bits plus 4 control bits that can be passed to the multiplex and/or controller. The 96 payload bits provide 2400 bps of error corrected bandwidth. The ¾ rate fec extends this to 3600 bps and the ¼ rate fec reduces it to 1200 bps.  These are all in the range of data rates useful in amateur digital voice and data applications in HF and VHF. With current codec technologies (e.g. LPCNet + Codec2), performance far exceeding that of the codecs deployed in amateur digital radio is viable. The symbol rate can be doubled to double the payloads to 2400, 4800, and 7200 bps which can provide high quality wideband voice. Note that these are real-time conversational modes. Arbitrarily high voice quality can be achieved using store-and-forward messaging modes. 
+160 channels are provided occupying 2 MHz of uplink bandwidth. Note that wideband channels may occupy an additional 2MHz or more of bandwidth. (The bands are split in the front-end digital processing using FFTs). 160 channels can support 320 users in PTT mode and more than a thousand channels in NET mode. Essentially, idle stations are parked and gain the channel when the current occupant drops. This process is assisted by the protocols. Operation is also possible with 1 channel per user which supports 160 simultaneous users for Fox-like operation.
 
 ## Narrowband Multiplex
 
-The NBM is transparent to the receivers as long as the basic parameters are met. Basically, the receiver makes available, for each channel, N bits per frame plus a pair of two bit label. Once the transmission is authenticated, the payload bits (e.g. 96) plus 2 label bits are passed to the NBM. The label bits allow the multiplex to signal primary or second data (e.g. voice data) and payload/control). This allows the NBM to insert common data e.g. telemetry and logs when the frame contains no data. The authenticated call sign is inserted in the control data in conformance with local administration (e.g. FCC) rules.
+The NBM is transparent to the receivers as long as the basic parameters are met. Basically, the receiver makes available, for each channel, N bits per frame plus a two bit label. Once the transmission is authenticated, the payload bits (e.g. 96) plus 2 label bits are passed to the NBM. The label bits allow the multiplex to signal primary or second data (e.g. voice data) and payload/control). This allows the NBM to insert common data e.g. telemetry and logs when the frame contains no data. The authenticated call sign is inserted in the control data in conformance with local administration (e.g. FCC) rules.
 The NBM allocates channels as Nx800 payloads. Each 800 bits occupies 32 bits of the downlink. A 2400 bps channel requires three 32 bit words. Labels are outside the payload with 2 bits per channel packed into 32-bit words. This allows receivers to know the location and label for each channel to find the channels of interest. 160 active channels produce 15360 payload bits plus 320 label bits for 15680 data bits. Additional control bits define the channel format. 
-Each channel has a dedicated data rate. Users must select channels of the desired bandwidth. This can change on the fly based on demand but not more than once be 25 frame superframe (1 second).
+Each channel has a dedicated data rate. Users must select channels of the desired bandwidth. This can change on the fly based on demand but not more than once per 25 frame superframe (1 second).
 The NBM always produces N DVB-S2 BBFRAMES each 40 ms cycle. The number depends on the allocated narrowband bandwith (in bits). About 40 2400 bit channels can be accommodated per frame and they appear in the downlink as a UDP packet encapsulated with GSE. The use of UDP allows simulation of the multiplexor through the internet. 
 
 ## Downlink
@@ -69,7 +69,7 @@ DVB-S2 allows 16200 or 64800 bits (not symbols) for BBFRAMES. For maximum flexib
 
 ### Pilots
 
-DVB-S2 allows each frame to include pilots or not. We always use pilot on to ease the burder on the receiver when skipping over BBFRAMES with MODCODs outside the earth stations capability. 
+DVB-S2 allows each frame to include pilots or not. We always use pilot on to ease the burder on the receiver when skipping over BBFRAMES with MODCODs outside the earth station's capability. 
 
 ### Output Filters and Spectral Regroth
 The output filter allows rollofs from .15 to .35. We normally use the largest setting. In addition, we must allow for spectrum regrowth when using non-linear output stages. This can be modelled as part of the implementation loss of the transmitter and is typically as much as 3dB. This is offset by the gain in DC efficiency.


### PR DESCRIPTION
I suspect `fec` should also be rendered as `FEC`.

The paragraph describing the label bits is not clear.